### PR TITLE
Modified DelegateConstraintAttribute and EnumConstraintAttribute to opti...

### DIFF
--- a/AssemblyToProcess/ClassWithMethodDelegateConstraint.cs
+++ b/AssemblyToProcess/ClassWithMethodDelegateConstraint.cs
@@ -7,3 +7,11 @@ public class ClassWithMethodDelegateConstraint
         
     }
 }
+
+public class ClassWithMethodDelegateConstraint2
+{
+    public void Method<[DelegateConstraint(typeof(System.Func<int>))] T>()
+    {
+
+    }
+}

--- a/AssemblyToProcess/ClassWithMethodEnumConstraint.cs
+++ b/AssemblyToProcess/ClassWithMethodEnumConstraint.cs
@@ -7,3 +7,11 @@ public class ClassWithMethodEnumConstraint
         
 	}
 }
+
+public class ClassWithMethodEnumConstraint2
+{
+    public void Method<[EnumConstraint(typeof(System.ConsoleColor))] T>()
+    {
+
+    }
+}

--- a/AssemblyToProcess/ClassWithTypeDelegateConstraint.cs
+++ b/AssemblyToProcess/ClassWithTypeDelegateConstraint.cs
@@ -3,3 +3,7 @@
 public class ClassWithTypeDelegateConstraint<[DelegateConstraint] T>
 {
 }
+
+public class ClassWithTypeDelegateConstraint2<[DelegateConstraint(typeof(System.Func<int>))] T>
+{
+}

--- a/AssemblyToProcess/ClassWithTypeEnumConstraint.cs
+++ b/AssemblyToProcess/ClassWithTypeEnumConstraint.cs
@@ -3,3 +3,7 @@ using ExtraConstraints;
 public class ClassWithTypeEnumConstraint<[EnumConstraint] T>
 {
 }
+
+public class ClassWithTypeEnumConstraint2<[EnumConstraint(typeof(System.ConsoleColor))] T>
+{
+}

--- a/AssemblyToProcess/InterfaceWithMethodDelegateConstraint.cs
+++ b/AssemblyToProcess/InterfaceWithMethodDelegateConstraint.cs
@@ -4,3 +4,8 @@ public interface InterfaceWithMethodDelegateConstraint
 {
 	void Method<[DelegateConstraint] T>();
 }
+
+public interface InterfaceWithMethodDelegateConstraint2
+{
+    void Method<[DelegateConstraint(typeof(System.Func<int>))] T>();
+}

--- a/AssemblyToProcess/InterfaceWithMethodEnumConstraint.cs
+++ b/AssemblyToProcess/InterfaceWithMethodEnumConstraint.cs
@@ -4,3 +4,8 @@ public interface InterfaceWithMethodEnumConstraint
 {
 	void Method<[EnumConstraint] T>();
 }
+
+public interface InterfaceWithMethodEnumConstraint2
+{
+    void Method<[EnumConstraint(typeof(System.ConsoleColor))] T>();
+}

--- a/AssemblyToProcess/InterfaceWithTypeDelegateConstraint.cs
+++ b/AssemblyToProcess/InterfaceWithTypeDelegateConstraint.cs
@@ -1,5 +1,10 @@
-﻿using ExtraConstraints;
+﻿using System;
+using ExtraConstraints;
 
 public interface InterfaceWithTypeDelegateConstraint<[DelegateConstraint] T>
+{
+}
+
+public interface InterfaceWithTypeDelegateConstraint2<[DelegateConstraint(typeof(Func<int>))] T>
 {
 }

--- a/AssemblyToProcess/InterfaceWithTypeEnumConstraint.cs
+++ b/AssemblyToProcess/InterfaceWithTypeEnumConstraint.cs
@@ -3,3 +3,7 @@ using ExtraConstraints;
 public interface InterfaceWithTypeEnumConstraint<[EnumConstraint] T>
 {
 }
+
+public interface InterfaceWithTypeEnumConstraint2<[EnumConstraint(typeof(System.ConsoleColor))] T>
+{
+}

--- a/ExtraConstraints/DelegateConstraintAttribute.cs
+++ b/ExtraConstraints/DelegateConstraintAttribute.cs
@@ -9,5 +9,33 @@ namespace ExtraConstraints
     [AttributeUsage(AttributeTargets.GenericParameter)]
     public class DelegateConstraintAttribute : Attribute
     {
+        private readonly Type _type;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public DelegateConstraintAttribute()
+        {
+            _type = typeof(Delegate);
+        }
+        
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="type">A type object representing the type of delegate to constrain the generic parameter to</param>
+        public DelegateConstraintAttribute(Type type)
+        {
+            if (!typeof(Delegate).IsAssignableFrom(type))
+                throw new ArgumentException(string.Format("The given type {0} is not a delegate", type.FullName));
+            _type = type;
+        }
+        
+        /// <summary>
+        /// Gets the type representing the delegate
+        /// </summary>
+        public Type Type
+        {
+            get { return _type; }
+        }
     }
 }

--- a/ExtraConstraints/EnumConstraintAttribute.cs
+++ b/ExtraConstraints/EnumConstraintAttribute.cs
@@ -8,5 +8,33 @@ namespace ExtraConstraints
     [AttributeUsage(AttributeTargets.GenericParameter)]
     public class EnumConstraintAttribute : Attribute
     {
+        private readonly Type _type;
+        
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public EnumConstraintAttribute()
+        {
+            _type = typeof(System.Enum);
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="type">A type object representing the type of enum to constrain the generic parameter to</param>
+        public EnumConstraintAttribute(Type type)
+        {
+            if (!type.IsEnum)
+                throw new ArgumentException(string.Format("The given type {0} is not an enum", type.FullName));
+            _type = type;
+        }
+
+        /// <summary>
+        /// Gets the type representing the enum 
+        /// </summary>
+        public Type Type
+        {
+            get { return _type; }
+        }
     }
 }

--- a/Tests/TaskTests.cs
+++ b/Tests/TaskTests.cs
@@ -47,6 +47,17 @@ public class TaskTests
                                 });
         Assert.AreEqual("The type 'string' must be a non-nullable value type in order to use it as parameter 'T' in the generic type or method 'ClassWithMethodEnumConstraint.Method<T>()'", exception.Message);
     }
+    
+    [Test]
+    public void MethodEnumAttributeShouldThrowWhenPassedAnInCompatibleEnum()
+    {
+        var exception = Try(() =>
+        {
+            var instance = assembly.GetInstance("ClassWithMethodEnumConstraint2");
+            instance.Method<System.ConsoleKey>();
+        });
+        Assert.AreEqual("The type 'System.ConsoleKey' cannot be used as type parameter 'T' in the generic type or method 'ClassWithMethodEnumConstraint2.Method<T>()'. There is no boxing conversion from 'System.ConsoleKey' to 'System.ConsoleColor'.", exception.Message);
+    }
 
     [Test]
     public void MethodWithEnumAttributeShouldBeCallable()
@@ -65,7 +76,17 @@ public class TaskTests
 		Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Enum));
 	}
 
-	[Test]
+    [Test]
+    public void MethodWithEnumAttributeShouldHaveDelegateConstraint2()
+    {
+        var genericParameterConstraints = assembly.GetType("ClassWithMethodEnumConstraint2")
+            .GetMethods()
+            .First(x => x.Name == "Method")
+            .GetGenericArguments();
+        Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(ConsoleColor));
+    }
+
+    [Test]
 	public void InterfaceMethodWithEnumAttributeShouldHaveDelegateConstraint()
 	{
 		var genericParameterConstraints = assembly.GetType("InterfaceWithMethodEnumConstraint")
@@ -74,6 +95,16 @@ public class TaskTests
 			.GetGenericArguments();
 		Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Enum));
 	}
+
+    [Test]
+    public void InterfaceMethodWithEnumAttributeShouldHaveDelegateConstraint2()
+    {
+        var genericParameterConstraints = assembly.GetType("InterfaceWithMethodEnumConstraint2")
+            .GetMethods()
+            .First(x => x.Name == "Method")
+            .GetGenericArguments();
+        Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(ConsoleColor));
+    }
 
     [Test]
 	public void ReferenceToExtraConstraintsShouldBeRemoved()
@@ -93,6 +124,17 @@ public class TaskTests
     }
 
     [Test]
+    public void MethodDelegateAttributeShouldThrowWhenPassedAnIncompatibleDelegate()
+    {
+        var exception = Try(() =>
+        {
+            var instance = assembly.GetInstance("ClassWithMethodDelegateConstraint2");
+            instance.Method<Func<string>>();
+        });
+        Assert.AreEqual("The type 'System.Func<string>' cannot be used as type parameter 'T' in the generic type or method 'ClassWithMethodDelegateConstraint2.Method<T>()'. There is no implicit reference conversion from 'System.Func<string>' to 'System.Func<int>'.", exception.Message);
+    }
+
+    [Test]
     public void MethodWithDelegateAttributeShouldBeCallable()
     {
         var instance = assembly.GetInstance("ClassWithMethodDelegateConstraint");
@@ -109,7 +151,17 @@ public class TaskTests
 		Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Delegate));
 	}
 
-	[Test]
+    [Test]
+    public void MethodWithDelegateAttributeShouldHaveDelegateConstraint2()
+    {
+        var genericParameterConstraints = assembly.GetType("ClassWithMethodDelegateConstraint2")
+            .GetMethods()
+            .First(x => x.Name == "Method")
+            .GetGenericArguments();
+        Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Func<int>));
+    }
+
+    [Test]
 	public void InterfaceMethodWithDelegateAttributeShouldHaveDelegateConstraint()
 	{
 		var genericParameterConstraints = assembly.GetType("InterfaceWithMethodDelegateConstraint")
@@ -120,6 +172,16 @@ public class TaskTests
 	}
 
     [Test]
+    public void InterfaceMethodWithDelegateAttributeShouldHaveDelegateConstraint2()
+    {
+        var genericParameterConstraints = assembly.GetType("InterfaceWithMethodDelegateConstraint2")
+            .GetMethods()
+            .First(x => x.Name == "Method")
+            .GetGenericArguments();
+        Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Func<int>));
+    }
+
+    [Test]
     public void ClassWithEnumAttributeShouldThrowWhenPassedANonEnum()
     {
         var exception = Try(() => {assembly.GetInstance<string>("ClassWithTypeEnumConstraint");});
@@ -127,9 +189,22 @@ public class TaskTests
     }
 
     [Test]
+    public void ClassWithEnumAttributeShouldThrowWhenPassedAnIncompatibleEnum()
+    {
+        var exception = Try(() => { assembly.GetInstance<ConsoleKey>("ClassWithTypeEnumConstraint2"); });
+        Assert.AreEqual("GenericArguments[0], 'System.ConsoleKey', on 'ClassWithTypeEnumConstraint2`1[T]' violates the constraint of type 'T'.", exception.Message);
+    }
+
+    [Test]
     public void ClassWithEnumAttributeShouldBeCallable()
     {
         assembly.GetInstance<AttributeTargets>("ClassWithTypeEnumConstraint");
+    }
+
+    [Test]
+    public void ClassWithEnumAttributeShouldBeCallable2()
+    {
+        assembly.GetInstance<ConsoleColor>("ClassWithTypeEnumConstraint");
     }
 
     [Test]
@@ -140,17 +215,38 @@ public class TaskTests
     }
 
     [Test]
+    public void ClassWithEnumAttributeShouldHaveEnumConstraint2()
+    {
+        var genericParameterConstraints = assembly.GetType("ClassWithTypeEnumConstraint2`1").GetGenericArguments();
+        Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(ConsoleColor));
+    }
+
+    [Test]
     public void InterfaceWithEnumAttributeShouldHaveEnumConstraint()
     {
 	    var genericParameterConstraints = assembly.GetType("InterfaceWithTypeEnumConstraint`1").GetGenericArguments();
 	    Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof (Enum));
     }
 
-	[Test]
+    [Test]
+    public void InterfaceWithEnumAttributeShouldHaveEnumConstraint2()
+    {
+        var genericParameterConstraints = assembly.GetType("InterfaceWithTypeEnumConstraint2`1").GetGenericArguments();
+        Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(ConsoleColor));
+    }
+
+    [Test]
     public void ClassWithDelegateAttributeShouldThrowWhenPassedNonDelegate()
     {
         var exception = Try(() => assembly.GetInstance<string>("ClassWithTypeDelegateConstraint"));
         Assert.AreEqual("GenericArguments[0], 'System.String', on 'ClassWithTypeDelegateConstraint`1[T]' violates the constraint of type 'T'.", exception.Message);
+    }
+
+    [Test]
+    public void ClassWithDelegateAttributeShouldThrowWhenPassedIncompatibleDelegate()
+    {
+        var exception = Try(() => assembly.GetInstance<Func<string>>("ClassWithTypeDelegateConstraint2"));
+        Assert.AreEqual("GenericArguments[0], 'System.Func`1[System.String]', on 'ClassWithTypeDelegateConstraint2`1[T]' violates the constraint of type 'T'.", exception.Message);
     }
 
     [Test]
@@ -159,19 +255,39 @@ public class TaskTests
         assembly.GetInstance<Action>("ClassWithTypeDelegateConstraint");
     }
 
-	[Test]
+    [Test]
+    public void ClassWithDelegateAttributeShouldBeCallable2()
+    {
+        assembly.GetInstance<Func<int>>("ClassWithTypeDelegateConstraint");
+    }
+
+    [Test]
 	public void ClassWithDelegateAttributeShouldHaveDelegateConstraint()
 	{
 		var genericParameterConstraints = assembly.GetType("ClassWithTypeDelegateConstraint`1").GetGenericArguments();
 		Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Delegate));
 	}
 
-	[Test]
+    [Test]
+    public void ClassWithDelegateAttributeShouldHaveDelegateConstraint2()
+    {
+        var genericParameterConstraints = assembly.GetType("ClassWithTypeDelegateConstraint2`1").GetGenericArguments();
+        Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Func<int>));
+    }
+
+    [Test]
 	public void InterfaceWithDelegateAttributeShouldHaveDelegateConstraint()
 	{
 		var genericParameterConstraints = assembly.GetType("InterfaceWithTypeDelegateConstraint`1").GetGenericArguments();
 		Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Delegate));
 	}
+
+    [Test]
+    public void InterfaceWithDelegateAttributeShouldHaveDelegateConstraint2()
+    {
+        var genericParameterConstraints = assembly.GetType("InterfaceWithTypeDelegateConstraint2`1").GetGenericArguments();
+        Assert.AreEqual(genericParameterConstraints.First().BaseType, typeof(Func<int>));
+    }
 
     static Exception Try(Action action)
     {


### PR DESCRIPTION
...onally accept a Type to constrain the constraint to. Also updated unit tests to test the new cases. Note that the two cases I have been unable to add as tests are passing in a non-delegate type to DelegateConstraintAttribute and passing in a non-enum type to EnumConstraintAttribute. These cases are handled and cause a WeavingException. However, since the weaving happens before any of the test begin, I do not know how to test these two cases. Adding these two cases would make the tests test for almost every eventuality I can think of.
